### PR TITLE
[AVP-4787] Fix Buildkite failures on instance scale-in

### DIFF
--- a/packer/linux/conf/buildkite-agent/systemd/buildkite-agent.service
+++ b/packer/linux/conf/buildkite-agent/systemd/buildkite-agent.service
@@ -14,7 +14,6 @@ Environment="USER=buildkite-agent"
 # The =- (rather than just = ) in the line below means that systemd won't complain if it can't find the file
 EnvironmentFile=-/var/lib/buildkite-agent/env
 ExecStart=/usr/bin/buildkite-agent start
-ExecStopPost=/usr/local/bin/terminate-instance
 RestartSec=5
 Restart=on-failure
 RestartForceExitStatus=SIGPIPE


### PR DESCRIPTION
Modify AMI to prevent EC2 instance termination on Buildkite agent shutdown.

Currently, we assign instance scale-in protection at the job level, so instances can be stopped without first disconnecting the Buildkite agent.

Since [this PR](https://github.com/AppliedNeuron/core-stack/pull/18648) will modify the instance scale-in protection strategy to follow Buildkite agent lifecycles rather than individual jobs (and Buildkite agents will now be shut down after an idle timeout), we want to ensure that the ASG instance is only stopped and not terminated on agent shutdown. This is to prevent having to spin up new instances and rebuild the Docker container on scale-out.