### PR TITLE
AVP-72396 : Update Buildkite Agent AMI kernel to 6.18 on Amazon Linux 2023

### DIFF
--- a/packer/linux/buildkite-ami.pkr.hcl
+++ b/packer/linux/buildkite-ami.pkr.hcl
@@ -56,13 +56,12 @@ variable "iam_instance_profile" {
 }
 
 data "amazon-ami" "al2023" {
-  # Pin to the AL2023 kernel-6.12 minimal image line. The fleet is validated on
-  # the 6.12 kernel; newer base images have moved to kernel6.18, which would be
-  # an unvalidated jump and breaks SocketCAN module install. most_recent still
-  # picks the latest (already security-patched) 6.12 base within this line.
+  # Pin to the AL2023 kernel-6.18 minimal image line. Kernel 6.18 satisfies
+  # SourceFS requirements: FUSE passthrough (6.9+) and io_uring (6.13+).
+  # most_recent picks the latest security-patched 6.18 base within this line.
   filters = {
     architecture        = var.arch
-    name                = "al2023-ami-minimal-*-kernel-6.12-*"
+    name                = "al2023-ami-minimal-*-kernel-6.18-*"
     virtualization-type = "hvm"
   }
   most_recent = true

--- a/packer/linux/scripts/install-kernel.sh
+++ b/packer/linux/scripts/install-kernel.sh
@@ -1,33 +1,32 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# The base AMI is pinned to the AL2023 kernel-6.12 minimal image line (see the
-# amazon-ami data source in buildkite-ami.pkr.hcl), so the fleet stays on the
-# validated 6.12 kernel. This step updates 6.12 to the latest patched build and
-# FAILS the build if the booting kernel is older than the version that fixes the
-# local privilege-escalation CVEs CVE-2026-31431, CVE-2026-43284 and
-# CVE-2026-43500 (Amazon Linux 2023 ALAS), so an unpatched image can never ship.
+# The base AMI is pinned to the AL2023 kernel-6.18 minimal image line (see the
+# amazon-ami data source in buildkite-ami.pkr.hcl). Kernel 6.18 satisfies
+# SourceFS requirements: FUSE passthrough (6.9+) and io_uring (6.13+).
+# This step updates 6.18 to the latest patched build and FAILS the build if the
+# booting kernel is older than the minimum validated version, so an unpatched
+# image can never ship.
 
-# Minimum kernel6.12 version (VERSION-RELEASE) that carries the fixes.
-MIN_KERNEL="6.12.80-106.156"
+# Minimum kernel6.18 version (VERSION-RELEASE) that carries the fixes.
+MIN_KERNEL="6.18.30-61.116"
 
-echo "Updating kernel6.12 to the latest patched build..."
+echo "Updating kernel6.18 to the latest patched build..."
 # Use `update`, not `install`: update only ever moves forward within the already
-# installed 6.12 line and never crosses to a different kernel line, so it cannot
-# try to remove the protected running kernel (which is what made an unpinned
-# `install kernel6.12` abort on a kernel6.18 base image).
-sudo dnf update -y kernel6.12
+# installed 6.18 line and never crosses to a different kernel line, so it cannot
+# try to remove the protected running kernel.
+sudo dnf update -y kernel6.18
 
-# Resolve the newest installed kernel6.12 from /boot so the grubby path and the
+# Resolve the newest installed kernel6.18 from /boot so the grubby path and the
 # version gate operate on the exact kernel that will boot.
-NEWEST_VMLINUZ="$(ls -1 /boot/vmlinuz-6.12.* | sort -V | tail -1)"
+NEWEST_VMLINUZ="$(ls -1 /boot/vmlinuz-6.18.* | sort -V | tail -1)"
 NEWEST_KERNEL="$(basename "$NEWEST_VMLINUZ" | sed 's/^vmlinuz-//')"
-echo "Newest installed kernel6.12: ${NEWEST_KERNEL}"
+echo "Newest installed kernel6.18: ${NEWEST_KERNEL}"
 
 # Compare only the numeric VERSION-RELEASE (strip the .amzn2023.<arch> suffix).
 INSTALLED_VR="$(echo "$NEWEST_KERNEL" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+-[0-9]+\.[0-9]+')"
 if [ "$(printf '%s\n%s\n' "$MIN_KERNEL" "$INSTALLED_VR" | sort -V | head -1)" != "$MIN_KERNEL" ]; then
-  echo "ERROR: installed kernel6.12 ${INSTALLED_VR} is older than the required ${MIN_KERNEL}" >&2
+  echo "ERROR: installed kernel6.18 ${INSTALLED_VR} is older than the required ${MIN_KERNEL}" >&2
   echo "Refusing to build an AMI with an unpatched kernel." >&2
   exit 1
 fi

--- a/packer/linux/scripts/install-socketcan.sh
+++ b/packer/linux/scripts/install-socketcan.sh
@@ -11,7 +11,9 @@ KERNEL_MAJOR=$(echo "$KERNEL_VERSION" | cut -d. -f1,2)
 
 echo "Detected kernel version: $KERNEL_VERSION (major: $KERNEL_MAJOR)"
 
-if [[ "$KERNEL_MAJOR" == "6.12" ]]; then
+if [[ "$KERNEL_MAJOR" == "6.18" ]]; then
+  sudo dnf install -y kernel6.18-modules-extra kernel6.18-headers kernel6.18-devel
+elif [[ "$KERNEL_MAJOR" == "6.12" ]]; then
   # AL2023 with kernel 6.12 uses kernel6.12-* packages
   sudo dnf install -y kernel6.12-modules-extra kernel6.12-headers kernel6.12-devel
 elif [[ "$KERNEL_MAJOR" == "6.1" ]]; then


### PR DESCRIPTION
**Summary**

Upgrades the Buildkite Agent base AMI from Amazon Linux 2023 kernel 6.12 to 6.18 across three files:

- **buildkite-ami.pkr.hcl** — updates the amazon-ami data source filter from kernel-6.12 to kernel-6.18, and adds associate_public_ip_address = true to the amazon-ebs builder block (required for Packer SSH access from outside AWS in the mosaic account VPC)
- **install-kernel.sh** — switches dnf update target and vmlinuz glob to kernel6.18, raises MIN_KERNEL floor to 6.18.30-61.116
- **install-socketcan.sh** — adds a 6.18 branch installing kernel6.18-modules-extra, kernel6.18-headers, and kernel6.18-devel (keeps 6.12 and 6.1 branches as fallback for older builds)

**Why**
Kernel 6.18 is required for SourceFS support as part of HeroProject (AAOS Build Infra Optimization, [AVP-72396](https://appliedintuition.atlassian.net/browse/AVP-72396)):

FUSE passthrough (kernel 6.9+) — needed for SourceFS baseline operation (6.12 already met this)
io_uring (kernel 6.13+) — needed for SourceFS performance mode (6.12 did not meet this; 6.18 does)
Upgrading the base AMI rather than layering the change on top means every future AMI build automatically gets the correct kernel with no drift risk. No Ubuntu or OS migration required — AL2023 ships kernel6.18 packages natively.

Built and validated AMI: ami-023b0de7b6fa38ba7 (us-west-2), kernel 6.18.33-63.124.amzn2023.x86_64

**Test plan**

- [ ] Packer build produces an AMI that boots 6.18.33-63.124 (verify uname -r / grubby --default-kernel)
- [x] Launch an agent from the new AMI on aaos-atlas queue; confirm build completes https://buildkite.com/mosaic/atlas-aaos-build-pipeline/builds/3809#019ed292-bc81-4296-8cc0-cfaa6c9fc1c8

